### PR TITLE
Disable motion detection by default on desktop

### DIFF
--- a/js/plax.js
+++ b/js/plax.js
@@ -274,6 +274,7 @@
     //
     //  opts - options for plax
     //    activityTarget - optional; plax will only work within the bounds of this element, if supplied.
+    //    enableMotionOnDesktop - optional, defaults to false (uses ontouchstart detection)
     //
     //  Examples
     //
@@ -282,14 +283,13 @@
     //
     // returns nothing
     enable: function(opts){
+      opts = opts || {};
       $(document).bind('mousemove.plax', function (e) {
-        if(opts){
-          plaxActivityTarget = opts.activityTarget || $(window)
-        }
+        plaxActivityTarget = opts.activityTarget || $(window)
         plaxifier(e)
       })
 
-      if(moveable()){
+      if((('ontouchstart' in document) || opts.enableMotionOnDesktop) && moveable()){
         window.ondevicemotion = function(e){detectMotion(e)}
       }
 


### PR DESCRIPTION
This isn't perfect, but it changes how Plax works by default on desktop.
Previously it would always be enabled if the browser supported it
(Firefox only?). Now it will be disabled unless you explicitly allow
desktop support. Detection is done by detecting 'ontouchstart' which is
only on mobile (for now).
