### PR TITLE
Use a simple low pass filter to filter out device acceleration noise

### DIFF
--- a/js/plax.js
+++ b/js/plax.js
@@ -34,6 +34,9 @@
       motionMax          = 1,
       motionAllowance    = .05,
       movementCycles     = 0,
+      motionLowPassFilter= 0.2,
+      motionLastX        = 1,
+      motionLastY        = 1,
       motionData         = {
         "xArray"  : [0,0,0,0,0],
         "yArray"  : [0,0,0,0,0],
@@ -156,6 +159,13 @@
       var accel= e.accelerationIncludingGravity,
           x = accel.x,
           y = accel.y
+
+      x = (x * motionLowPassFilter) + (motionLastX * (1.0 - motionLowPassFilter));
+      y = (y * motionLowPassFilter) + (motionLastY * (1.0 - motionLowPassFilter));
+
+      motionLastX = x;
+      motionLastY = y;
+
       if(motionData.xArray.length >= 5){
         motionData.xArray.shift()
       }


### PR DESCRIPTION
This pull request adds a simple low pass filter to hide some of the noise from different accelerometers.  You may want to tweak the filter value from 0.2 to something smaller.  I found this value to be enough to prevent alot of giggle on the Plax example pages.
