### PR TITLE
Allow clearing of previously defined layers when disabling

### DIFF
--- a/js/plax.js
+++ b/js/plax.js
@@ -312,10 +312,14 @@
     //    $.plax.disable()
     //    # plax no longer runs
     //
+    //    $.plax.disable({ "clearLayers": true })
+    //    # plax no longer runs and all layers are forgotten
+    //
     // returns nothing
-    disable: function(){
+    disable: function(opts){
       $(document).unbind('mousemove.plax')
       window.ondevicemotion = undefined
+      if (opts && typeof opts.clearLayers === 'boolean' && opts.clearLayers) layers = []
     }
   }
 

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,10 @@ __Parameters__
 
 Disable parallaxing.
 
+__Parameters__
+
+`clearLayers` &mdash; Boolean: (optional) clears all previously defined layers when disabling.
+
 
 ## Best Practices
 


### PR DESCRIPTION
I had a specific need to clear all the plax layers I previously defined when disabling, so that I could enable again with a different set of layers.

This PR adds one option to `disable` to allow for that.
