### PR TITLE
Restrict the input from the gyro to the same range as desktop version.

### DIFF
--- a/js/plax.js
+++ b/js/plax.js
@@ -31,6 +31,7 @@
       layers             = [],
       plaxActivityTarget = $(window),
       motionMax          = 1,
+      motionMin          = -1,
       motionStartX       = null,
       motionStartY       = null,
       ignoreMoveable     = false
@@ -168,6 +169,12 @@
       // Admittedly fuzzy measurements
       x = values.x / 30
       y = values.y / 30
+      // Ensure not outside of expected range, -1 to 1
+      x = x < motionMin ? motionMin : (x > motionMax ? motionMax : x)
+      y = y < motionMin ? motionMin : (y > motionMax ? motionMax : y)
+      // Normalize from -1 to 1 => 0 to 1
+      x = (x + 1) / 2
+      y = (y + 1) / 2
     }
 
     var hRatio = x/((moveable() == true) ? motionMax : plaxActivityTarget.width()),


### PR DESCRIPTION
When merging holman/gyro (commit 67997a7fa02ed1732dddfdffb1ba8f9a20950122) the range restriction that was applied on the old accelerometer code was lost.

With the gyro code, there is no actual restriction on the x/y values (other than the -180 to 180 divided by 30 range) that can be the result after the motion event calculation.

Right now, it is possible to get values quite wide in range, thus getting a parallax offset far larger than the ranges defined for each layer.

In the old accelerometer code, the min and max values was restricted to -1 to 1, and then "normalized" to the range 0 to 1, which is what I've reapplied with slightly rewritten code.

Another side effect by the code in place before the suggested change is that when using gyro, the starting position of the images would always correspond to pointing at the top left corner, when using the desktop methods. With the suggested change, starting position will be corresponding to pointing at the middle of the image instead.

As I'm unsure what thoughts there are on backwards compatibility, I'm very open to suggestions for this pull request, and as I see it there are three possible ways forward;
- Merge as is, considering the expanded ranges introduced with gyro changes as a bug.
- Condition the fix as an option to enable(). Does not break anything for existing users.
- Add an option to enable() to use the "unrestricted" behavior as it is today, but default option being that the fix is applied.

The main question I guess is how many users are aware of the behavior when using gyro. Looking at the 404 and 500 page of github it's apparent that it's been tested quite thoroughly on desktop, but load it up on a phone and you see quite a few artifacts/unexpected edges when you are tilting a bit (not necessarily that much, considering the starting position).
