### PR TITLE
Configurable degrees of tilt for gyro parallaxing

### DIFF
--- a/js/plax.js
+++ b/js/plax.js
@@ -30,6 +30,7 @@
       lastRender         = new Date().getTime(),
       layers             = [],
       plaxActivityTarget = $(window),
+      motionDegrees      = 30,
       motionMax          = 1,
       motionMin          = -1,
       motionStartX       = null,
@@ -167,8 +168,8 @@
       values = valuesFromMotion(e)
 
       // Admittedly fuzzy measurements
-      x = values.x / 30
-      y = values.y / 30
+      x = values.x / motionDegrees
+      y = values.y / motionDegrees
       // Ensure not outside of expected range, -1 to 1
       x = x < motionMin ? motionMin : (x > motionMax ? motionMax : x)
       y = y < motionMin ? motionMin : (y > motionMax ? motionMax : y)
@@ -210,10 +211,12 @@
     //
     // returns nothing
     enable: function(opts){
+      if (opts) {
+        if (opts.activityTarget) plaxActivityTarget = opts.activityTarget || $(window)
+        if (typeof opts.gyroRange === 'number' && opts.gyroRange > 0) motionDegrees = opts.gyroRange
+      }
+
       $(document).bind('mousemove.plax', function (e) {
-        if(opts){
-          plaxActivityTarget = opts.activityTarget || $(window)
-        }
         plaxifier(e)
       })
 

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ __Parameters__
 
 `activityTarget` &mdash; Object: (optional) sets a specific DOM element over which Plax will track the mouse.
 
+`gyroRange` &mdash; Integer / Float: (optional) sets the degrees of tilt needed to reach full movement in one direction, from the center position. For the full range, two times the degrees tilt is needed. Default value: 30.
 
 ### disable()
 


### PR DESCRIPTION
(Sorry, seems GitHub won't let me create a pull request without my merging of branches as an additional commit)

A easy change that I figured while restricting the range for the gyro was configurable range of tilt, as it today was hard coded to limit the range to a total of 60 degrees (30 degrees in each direction from the center position).

This will bring back options to do what was removed when restricting the range. With this change the same result can be achieved by increasing the x and y range for the objects, and instead increase the gyroRange value when enabling plax.

Also, while fixing this I noticed that the activity target was actually being set upon every mousemove event.
