### PR TITLE
Store the actual starting positions.

### DIFF
--- a/js/plax.js
+++ b/js/plax.js
@@ -88,8 +88,8 @@
           'right' :'',
           'bottom':''
         })
-        layer.originX = layer.startX = this.offsetLeft
-        layer.originY = layer.startY = this.offsetTop
+        layer.originX = layer.startX = position.left
+        layer.originY = layer.startY = position.top
       }
 
       layer.startX -= layer.inversionFactor * Math.floor(layer.xRange/2)


### PR DESCRIPTION
If mouse pointer is positioned at middle of screen when activating Plax, if there is any margin applied to any elements they will make a "leap" upon first plaxifier update.

This seems to stem from the offsetLeft and offsetTop not taking the margin into consideration, which the jQuery .position() values does.

Clearest example of this I've found is the GitHub error 500 page, where the "Ooops" text has a 10px margin defined. Positioning the mouse pointer near the middle of the page, and reloading the page, all elements but the text layer can be made to stay roughly in the same place, but the text layer will always make a jump, of roughly 10 pixels.
