### PR TITLE
Fixes a typo breaking JS concatenation

### DIFF
--- a/js/plax.js
+++ b/js/plax.js
@@ -262,4 +262,4 @@
 
 })(function () {
   return typeof jQuery !== 'undefined' ? jQuery : ender
-}())
+}());


### PR DESCRIPTION
Used to break JS concatenation w/ GruntJS since the very last semicolon was missing.
